### PR TITLE
Add TODO comments for identified improvement areas

### DIFF
--- a/FileDupeFinder.py
+++ b/FileDupeFinder.py
@@ -32,10 +32,12 @@ class FileDupes:
         self.file_list: List[FileInfo] = []
         self.dupe_candidates: List[DupeInfo] = []
         self.dupes: List[DupeInfo] = []
-        self.dir_count = 0
+        self.dir_count = 0  # TODO: dir_count is tracked but never printed or returned; use it in a summary or remove it.
 
     def run(self):
         """Execute the duplicate finding process."""
+        # TODO: Add a --verbose flag that prints progress counts after each stage
+        #       (files found, candidates, confirmed dupes) so large scans give feedback.
         self._walk_tree()
         print(f"Found {len(self.file_list)} files to be processed")
         
@@ -48,6 +50,8 @@ class FileDupes:
     @staticmethod
     def _md5_for_file(path: Path, num_chunks: Optional[int] = None) -> str:
         """Calculate MD5 hash for a file."""
+        # TODO: Switch from MD5 to SHA-256; MD5 is cryptographically broken and
+        #       collision resistance is not guaranteed, even if accidental collisions are rare.
         md5 = hashlib.md5()
         try:
             with path.open('rb') as f:
@@ -58,10 +62,17 @@ class FileDupes:
             return md5.hexdigest()
         except OSError as e:
             print(f"Error reading {path}: {e}", file=sys.stderr)
+            # TODO: Returning "" on error causes unreadable files to match each other as
+            #       "duplicates". Use a sentinel value (e.g. None) and skip those entries.
             return ""
 
     def _walk_tree(self):
         """Walk the directory tree and collect file information."""
+        # TODO: pathlib.Path.walk() requires Python 3.12+. Document this requirement
+        #       explicitly, or replace with os.walk() for broader compatibility.
+        # TODO: The entire file list is accumulated in memory before hashing begins.
+        #       On filesystems with millions of files this can exhaust memory; consider
+        #       a streaming/generator approach that feeds files directly into hashing.
         for root, dirs, files in self.root_path.walk(top_down=True):
             self.dir_count += 1
             
@@ -105,6 +116,10 @@ class FileDupes:
         for size, files in size_dict.items():
             if len(files) > 1:
                 for info in files:
+                    # TODO: The 10-chunk (80KB) partial hash assumes file differences appear
+                    #       early. Files sharing identical headers (ISO images, video containers,
+                    #       database dumps) will always pass this check and trigger expensive full
+                    #       reads. Consider sampling from multiple offsets or increasing coverage.
                     md5 = self._md5_for_file(info.path, 10)
                     if md5:
                         self.dupe_candidates.append(DupeInfo(size, md5, info.path, info.ino))
@@ -129,6 +144,9 @@ class FileDupes:
 
                 for full_md5, confirmed_dupes in full_md5_dict.items():
                     if len(confirmed_dupes) > 1:
+                        # TODO: Hard links (files sharing the same inode) are reported as
+                        #       duplicates even though they occupy no extra disk space. Filter
+                        #       groups where all entries share the same inode before appending.
                         for info in confirmed_dupes:
                             self.dupes.append(DupeInfo(info.size, full_md5, info.path, info.ino))
 

--- a/filedupe.go
+++ b/filedupe.go
@@ -44,6 +44,8 @@ func newFileDupes(path string, size int64, outfilename string) *FileDupes {
 }
 
 func (fd *FileDupes) run() {
+	// TODO: Add a -v / --verbose flag that prints progress counts after each stage
+	//       (files found, candidates, confirmed dupes) so large scans give feedback.
 	fd.walkTree()
 	fmt.Printf("Found %d files to be processed\n", len(fd.fileList))
 	fd.findPotentialDupes()
@@ -53,6 +55,9 @@ func (fd *FileDupes) run() {
 }
 
 func (fd *FileDupes) walkTree() {
+	// TODO: The entire file list is accumulated in memory before hashing begins.
+	//       On filesystems with millions of files this can exhaust memory; consider
+	//       a streaming approach that feeds files into hashing as they are discovered.
 	err := filepath.Walk(fd.rootPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			// Handle permission errors or other issues by logging and skipping
@@ -60,7 +65,7 @@ func (fd *FileDupes) walkTree() {
 			return filepath.SkipDir
 		}
 		if info.IsDir() {
-			fd.dirCount++
+			fd.dirCount++ // TODO: dirCount is tracked but never printed or returned; use it in a summary or remove it.
 			for _, exclude := range fd.excludeList {
 				if info.Name() == exclude {
 					return filepath.SkipDir
@@ -90,7 +95,12 @@ func (fd *FileDupes) findPotentialDupes() {
 	}
 
 	var wg sync.WaitGroup
-	semaphore := make(chan struct{}, 8) // Limit concurrent goroutines
+	// TODO: The concurrency limit of 8 is hardcoded. On spinning disks 8 concurrent
+	//       readers cause seek thrashing; on SSDs more parallelism helps. Expose this
+	//       as a -j / --jobs flag so callers can tune it.
+	// TODO: There is no context/cancellation support. A long scan cannot be interrupted
+	//       cleanly on Ctrl-C. Thread a context.Context through and respect cancellation.
+	semaphore := make(chan struct{}, 8)
 	var mu sync.Mutex
 
 	for _, files := range sizeMap {
@@ -101,8 +111,11 @@ func (fd *FileDupes) findPotentialDupes() {
 				go func(f *fileInfo) {
 					defer wg.Done()
 					defer func() { <-semaphore }()
-					
-					// Partial MD5
+
+					// TODO: The 10-chunk (80KB) partial hash assumes differences appear early.
+					//       Files with identical headers (ISO images, video containers) will always
+					//       pass this check and trigger expensive full reads. Consider sampling
+					//       from multiple offsets or increasing coverage.
 					pMD5 := calculateMD5(f.path, 10)
 					if pMD5 != "" {
 						f.partialMD5 = pMD5
@@ -162,6 +175,9 @@ func (fd *FileDupes) confirmDupes() {
 
 	for _, files := range fullMD5Map {
 		if len(files) > 1 {
+			// TODO: Hard links (files sharing the same inode) are reported as duplicates even
+			//       though they occupy no extra disk space. Filter groups where all entries share
+			//       the same inode before appending to fd.dupes.
 			fd.dupes = append(fd.dupes, files...)
 		}
 	}
@@ -192,8 +208,12 @@ func (fd *FileDupes) writeDupeFile() {
 }
 
 func calculateMD5(filename string, numChunks int) string {
+	// TODO: Switch from MD5 to SHA-256 (crypto/sha256). MD5 is cryptographically broken;
+	//       while accidental collisions are rare, using SHA-256 costs little and removes ambiguity.
 	file, err := os.Open(filename)
 	if err != nil {
+		// TODO: Returning "" on error causes unreadable files to match each other as
+		//       "duplicates". Return a sentinel (e.g. a distinct error value) and skip those entries.
 		return ""
 	}
 	defer file.Close()


### PR DESCRIPTION
Documents actionable issues inline at the relevant code locations:
- Hard links falsely reported as duplicates (both files)
- 80KB partial hash heuristic can miss duplicates with identical headers
- MD5 should be replaced with SHA-256
- Silent empty-string return on read error causes false duplicate matches
- Entire file list held in memory before hashing (OOM risk)
- Python 3.12+ requirement undocumented (pathlib.Path.walk)
- Go semaphore concurrency limit hardcoded (no -j flag)
- Go goroutine pool lacks context/cancellation support
- dirCount tracked but never used in output
- No --verbose / progress reporting flag

https://claude.ai/code/session_0175eHHGosV9Wh7S967kFWVu